### PR TITLE
New GitHub workflow that uses dotnet format

### DIFF
--- a/.github/workflows/dotnet_format.yaml
+++ b/.github/workflows/dotnet_format.yaml
@@ -17,4 +17,4 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Format
-        run: dotnet format --verify-no-changes --verbosity normal
+        run: dotnet format --verify-no-changes --verbosity quiet

--- a/.github/workflows/dotnet_format.yaml
+++ b/.github/workflows/dotnet_format.yaml
@@ -1,0 +1,20 @@
+name: Dotnet Format
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ['5.0.x', '6.0.x']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Format
+        run: dotnet format --verify-no-changes --verbosity normal

--- a/Program.cs
+++ b/Program.cs
@@ -19,6 +19,6 @@ app.MapControllerRoute(
     name: "default",
     pattern: "{controller}/{action=Index}/{id?}");
 
-app.MapFallbackToFile("index.html");;
+app.MapFallbackToFile("index.html"); ;
 
 app.Run();


### PR DESCRIPTION
I added a new workflow that has the same setup steps since it's dotnet, but this one runs the `dotnet format` command to make sure all the ASP.NET related code is up to spec and consistent. The workflow itself doesn't edit the branch, just exit with nonzero error code if it sees things it would want to format. It also has decent enough error messages to tell you where to fix stuff. Locally you just run `dotnet format` with no arguments from the repo root and it'll make sure the entire repo is up to spec.