### PR TITLE
Set up ServerApi utility in frontend

### DIFF
--- a/ClientApp/src/app/fetch-data/fetch-data.component.ts
+++ b/ClientApp/src/app/fetch-data/fetch-data.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { ServerApi } from '../server-api/server-api.service';
 
 @Component({
   selector: 'app-fetch-data',
@@ -8,14 +8,13 @@ import { HttpClient } from '@angular/common/http';
 export class FetchDataComponent {
   public forecasts: WeatherForecast[] = [];
 
-  constructor(http: HttpClient, @Inject('BASE_URL') baseUrl: string) {
-    http.get<WeatherForecast[]>(baseUrl + 'weatherforecast').subscribe(result => {
-      this.forecasts = result;
-    }, error => console.error(error));
+  constructor(serverApi: ServerApi) {
+    serverApi.getWeatherForecast<WeatherForecast[]>()
+      .subscribe(data => this.forecasts = data);
   }
 }
 
-interface WeatherForecast {
+export interface WeatherForecast {
   date: string;
   temperatureC: number;
   temperatureF: number;

--- a/ClientApp/src/app/server-api/server-api.service.spec.ts
+++ b/ClientApp/src/app/server-api/server-api.service.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { ServerApi } from './server-api.service';
+import { WeatherForecast } from '../fetch-data/fetch-data.component';
+import { defer } from 'rxjs';
+
+describe('ServerApi', () => {
+  let httpClientSpy: jasmine.SpyObj<HttpClient>;
+  let serverApi: ServerApi;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ HttpClientTestingModule ],
+      providers: [ 
+        ServerApi,
+        {
+          provide: 'BASE_URL',
+          useValue: '/'
+        }
+      ],
+    });
+
+    httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
+    serverApi = TestBed.inject(ServerApi);
+    serverApi.setHttpClient(httpClientSpy);
+  });
+
+  it('should return mock getWeatherForecast', () => {
+    const testData: WeatherForecast[] = [{
+      date: '2022-11-14T23:28:27.95936-08:00',
+      temperatureC: 27,
+      temperatureF: 80,
+      summary: 'Warm'
+    }];
+
+    // set what the http client's 'get' function should return
+    // extra junk within returnValue to convert testData to Observable<WeatherForecast[]>
+    httpClientSpy.get.and.returnValue(defer(() => Promise.resolve(testData)));
+
+    // make the test get
+    serverApi.getWeatherForecast<WeatherForecast[]>().subscribe(data =>
+      expect(data).withContext('checking return value').toEqual(testData));
+    
+    // we expect one get to have been made
+    expect(httpClientSpy.get.calls.count()).withContext('checking # of calls').toBe(1);
+  });
+});

--- a/ClientApp/src/app/server-api/server-api.service.spec.ts
+++ b/ClientApp/src/app/server-api/server-api.service.spec.ts
@@ -2,9 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
+import { defer } from 'rxjs';
+
 import { ServerApi } from './server-api.service';
 import { WeatherForecast } from '../fetch-data/fetch-data.component';
-import { defer } from 'rxjs';
 
 describe('ServerApi', () => {
   let httpClientSpy: jasmine.SpyObj<HttpClient>;

--- a/ClientApp/src/app/server-api/server-api.service.ts
+++ b/ClientApp/src/app/server-api/server-api.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+
 import { Observable } from 'rxjs';
 
 @Injectable({providedIn: 'root'})
@@ -19,7 +20,7 @@ export class ServerApi {
   /**
    * Simple http GET of the `'weatherforecast'` endpoint that's provided in the sample.
    * No error checking is done
-   * @type The type that you expect to receive in the result (`WeatherForecast`)
+   * @type The type that you expect to receive in the result (`WeatherForecast[]`)
    * @return An `Observable<T>` that stores the body of the HTTP response
    */
   getWeatherForecast<T>(): Observable<T> {

--- a/ClientApp/src/app/server-api/server-api.service.ts
+++ b/ClientApp/src/app/server-api/server-api.service.ts
@@ -16,7 +16,12 @@ export class ServerApi {
     this.http = http;
   }
 
-  // support the fake WeatherForecasts get that it gave us
+  /**
+   * Simple http GET of the `'weatherforecast'` endpoint that's provided in the sample.
+   * No error checking is done
+   * @type The type that you expect to receive in the result (`WeatherForecast`)
+   * @return An `Observable<T>` that stores the body of the HTTP response
+   */
   getWeatherForecast<T>(): Observable<T> {
     return this.http.get<T>(
       `${this.baseUrl}weatherforecast`,

--- a/ClientApp/src/app/server-api/server-api.service.ts
+++ b/ClientApp/src/app/server-api/server-api.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, Inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({providedIn: 'root'})
+export class ServerApi {
+  baseUrl: string;
+  http: HttpClient;
+
+  constructor(http: HttpClient, @Inject('BASE_URL') baseUrl: string) {
+    this.baseUrl = baseUrl;
+    this.http = http;
+  }
+
+  setHttpClient(http: HttpClient) {
+    this.http = http;
+  }
+
+  // support the fake WeatherForecasts get that it gave us
+  getWeatherForecast<T>(): Observable<T> {
+    return this.http.get<T>(
+      `${this.baseUrl}weatherforecast`,
+      {
+        // to get the full HttpResponse instead of just the body, set observe to 'response'
+        observe: 'body',
+        responseType: 'json'
+      }
+    );
+  }
+}


### PR DESCRIPTION
To help with the frontend side of the interactions between the frontend and backend, I added the ServerApi utility. It separates out  some of the http getting logic, making it modular and unit-testable. Logic for making more http requests will be added in server-api.service.ts, and the unit tests for each one will be added in server-api.service.spec.ts.