### PR TITLE
Collapse sprints icon, sprint options spacing

### DIFF
--- a/ClientApp/src/app/components/pages/project-page/project-page.component.html
+++ b/ClientApp/src/app/components/pages/project-page/project-page.component.html
@@ -69,7 +69,7 @@
       <div class="sprint-options">
         <p-button
           id="collapse-all-button"
-          icon="pi pi-list"
+          [icon]="collapseButtonIcon"
           [label]="collapseButtonText"
           styleClass="p-button-sm sprint-option"
           (onClick)="toggleCollapseSprints()"

--- a/ClientApp/src/app/components/pages/project-page/project-page.component.scss
+++ b/ClientApp/src/app/components/pages/project-page/project-page.component.scss
@@ -24,7 +24,7 @@ color-inplace, title-inplace {
 .sprint-options {
   width: 100%;
   display: grid;
-  column-gap: 0.75rem;
+  column-gap: 1.5rem;
   grid-template-columns: repeat(2, auto);
   grid-template-rows: 100%;
 }

--- a/ClientApp/src/app/components/pages/project-page/project-page.component.ts
+++ b/ClientApp/src/app/components/pages/project-page/project-page.component.ts
@@ -36,6 +36,7 @@ export class ProjectPageComponent {
   projectData!: ProjectData;
 
   collapseButtonText: 'Collapse All' | 'Expand All' = 'Collapse All';
+  collapseButtonIcon: 'pi pi-chevron-up' | 'pi pi-chevron-down' = 'pi pi-chevron-up';
   sprintsCollapsed: boolean = false;
   completedSprintsShown: boolean = false;
 
@@ -83,6 +84,7 @@ export class ProjectPageComponent {
         }
       }
       this.collapseButtonText = 'Expand All';
+      this.collapseButtonIcon = 'pi pi-chevron-down';
     } else {
       for (const sprintDropdown of this.sprintDropdowns.toArray()) {
         if (!(sprintDropdown as any).hidden) {
@@ -90,6 +92,7 @@ export class ProjectPageComponent {
         }
       }
       this.collapseButtonText = 'Collapse All';
+      this.collapseButtonIcon = 'pi pi-chevron-up';
     }
     this.sprintsCollapsed = !this.sprintsCollapsed;
   }


### PR DESCRIPTION
Two more small notes the ui/uix team had:
- Change the collapse button icon to be more representative of that action, so I switched it to a chevron arrow instead of the basic list icon I had it as before
- Separate out the two sprint options a bit more to make the checkbox for showing completed sprints a bit more noticeable