### PR TITLE
Add borders to funds-inplace and title-inplace

### DIFF
--- a/ClientApp/src/app/components/inplaces/funds-inplace/funds-inplace.component.scss
+++ b/ClientApp/src/app/components/inplaces/funds-inplace/funds-inplace.component.scss
@@ -8,5 +8,7 @@
 :host ::ng-deep {
   .p-inplace-display {
     font-size: large;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--surface-d);
   }
 }

--- a/ClientApp/src/app/components/inplaces/title-inplace/title-inplace.component.scss
+++ b/ClientApp/src/app/components/inplaces/title-inplace/title-inplace.component.scss
@@ -23,6 +23,11 @@
       font-weight: 400;
     }
   }
+
+  .p-inplace-display {
+    border-radius: var(--border-radius);
+    border: 1px solid var(--surface-d);
+  }
 }
 
 .p-buttonset {


### PR DESCRIPTION
Just another quick styling update the ui/ux team requested to make it more recognizable that the inplace components are clickable.