### PR TITLE
Fix API call for deleting task relations

### DIFF
--- a/Controllers/TasksToTasksController.cs
+++ b/Controllers/TasksToTasksController.cs
@@ -114,7 +114,7 @@ namespace Cuttlefish.Controllers
         }
 
         // DELETE: api/TasksToTasks/inID/depID
-        [HttpDelete("{id}")]
+        [HttpDelete("{independentID}/{dependentID}")]
         public async Task<IActionResult> DeleteTasksToTasksByIDS(int independentID, int dependentID)
         {
             var tasksToTasks = _context.TasksToTasks.Where(i => i.independentTaskID == independentID && i.dependentTaskID == dependentID).FirstAsync().Result;


### PR DESCRIPTION
Not sure if this only affects Swagger, but the attribute wasn't set properly by me here, leading to a conflicting API call