### PR TITLE
Footers and 404s

### DIFF
--- a/ClientApp/src/app/app.component.css
+++ b/ClientApp/src/app/app.component.css
@@ -1,3 +1,14 @@
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+.page-wrapper {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-height: 100vh;
+}
+
 .container {
   margin: 1.5rem auto;
 }

--- a/ClientApp/src/app/app.component.html
+++ b/ClientApp/src/app/app.component.html
@@ -1,7 +1,9 @@
 <body>
-  <app-nav-menu *ngIf="!hideNavMenu"></app-nav-menu>
-  <div class="container">
-    <router-outlet (activate)="assignHideNavMenu($event)"></router-outlet>
+  <div class="page-wrapper">
+    <app-nav-menu *ngIf="!hideNavMenu"></app-nav-menu>
+    <div class="container">
+      <router-outlet (activate)="assignHideNavMenu($event)"></router-outlet>
+    </div>
+    <app-footer></app-footer>
   </div>
-  <app-footer></app-footer>
 </body>

--- a/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.css
+++ b/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.css
@@ -1,0 +1,7 @@
+.not-found-title {
+    padding-top: 1rem; /* Adjust the value as needed for your desired spacing */
+  }
+  
+  .not-found-reason {
+    padding-top: 1rem; /* Adjust the value as needed for your desired spacing */
+  }

--- a/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.html
+++ b/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.html
@@ -4,36 +4,27 @@
   
     <h3 class="not-found-reason" *ngIf="this.notFoundReason === this.NotFoundReason.Unknown">
         The page at the URL you requested does not exist.
-        <p>If you believe this to be an error, please <a href="https://github.com/NathanJesudason/Cuttlefish/issues/new" 
-            target="_blank" rel="noopener noreferrer">help us by reporting it</a>.</p>
-
     </h3>
   
     <h3 class="not-found-reason" *ngIf="this.notFoundReason === this.NotFoundReason.Project">
         Project data wasn't found!
-        <p>If you believe this to be an error, please <a href="https://github.com/NathanJesudason/Cuttlefish/issues/new" 
-            target="_blank" rel="noopener noreferrer">help us by reporting it</a>.</p>
-
     </h3>
   
     <h3 class="not-found-reason" *ngIf="this.notFoundReason === this.NotFoundReason.Sprint">
         Sprint data wasn't found!
-        <p>If you believe this to be an error, please <a href="https://github.com/NathanJesudason/Cuttlefish/issues/new" 
-            target="_blank" rel="noopener noreferrer">help us by reporting it</a>.</p>
-
     </h3>
   
     <h3 class="not-found-reason" *ngIf="this.notFoundReason === this.NotFoundReason.Task">
         Task data wasn't found!
-        <p>If you believe this to be an error, please <a href="https://github.com/NathanJesudason/Cuttlefish/issues/new" 
-            target="_blank" rel="noopener noreferrer">help us by reporting it</a>.</p>
-
     </h3>
   
     <h3 class="not-found-reason" *ngIf="this.invalidId !== undefined">
         You tried to use this invalid ID: {{ this.invalidId }}<br>
-        If you believe this to be an error, please <a href="https://github.com/NathanJesudason/Cuttlefish/issues/new" 
-            target="_blank" rel="noopener noreferrer">help us by reporting it</a>.
+    </h3>
+
+    <h3>
+        <p>If you believe this to be an error, please <a href="https://github.com/NathanJesudason/Cuttlefish/issues/new" 
+            target="_blank" rel="noopener noreferrer">help us by reporting it</a>.</p>
     </h3>
 
 </div>

--- a/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.html
+++ b/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.html
@@ -1,9 +1,39 @@
-<h2 *ngIf="this.notFoundReason === this.NotFoundReason.Unknown">Invalid URL!</h2>
+<div class="not-found-container">
 
-<h2 *ngIf="this.notFoundReason === this.NotFoundReason.Project">Project wasn't found!</h2>
+    <h1 class="not-found-title">404: Page not found.</h1>
+  
+    <h3 class="not-found-reason" *ngIf="this.notFoundReason === this.NotFoundReason.Unknown">
+        The page at the URL you requested does not exist.
+        <p>If you believe this to be an error, please <a href="https://github.com/NathanJesudason/Cuttlefish/issues/new" 
+            target="_blank" rel="noopener noreferrer">help us by reporting it</a>.</p>
 
-<h2 *ngIf="this.notFoundReason === this.NotFoundReason.Sprint">Sprint wasn't found!</h2>
+    </h3>
+  
+    <h3 class="not-found-reason" *ngIf="this.notFoundReason === this.NotFoundReason.Project">
+        Project data wasn't found!
+        <p>If you believe this to be an error, please <a href="https://github.com/NathanJesudason/Cuttlefish/issues/new" 
+            target="_blank" rel="noopener noreferrer">help us by reporting it</a>.</p>
 
-<h2 *ngIf="this.notFoundReason === this.NotFoundReason.Task">Task wasn't found!</h2>
+    </h3>
+  
+    <h3 class="not-found-reason" *ngIf="this.notFoundReason === this.NotFoundReason.Sprint">
+        Sprint data wasn't found!
+        <p>If you believe this to be an error, please <a href="https://github.com/NathanJesudason/Cuttlefish/issues/new" 
+            target="_blank" rel="noopener noreferrer">help us by reporting it</a>.</p>
 
-<h3 *ngIf="this.invalidId !== undefined">Attempted id: {{ this.invalidId }}</h3>
+    </h3>
+  
+    <h3 class="not-found-reason" *ngIf="this.notFoundReason === this.NotFoundReason.Task">
+        Task data wasn't found!
+        <p>If you believe this to be an error, please <a href="https://github.com/NathanJesudason/Cuttlefish/issues/new" 
+            target="_blank" rel="noopener noreferrer">help us by reporting it</a>.</p>
+
+    </h3>
+  
+    <h3 class="not-found-reason" *ngIf="this.invalidId !== undefined">
+        You tried to use this invalid ID: {{ this.invalidId }}<br>
+        If you believe this to be an error, please <a href="https://github.com/NathanJesudason/Cuttlefish/issues/new" 
+            target="_blank" rel="noopener noreferrer">help us by reporting it</a>.
+    </h3>
+
+</div>

--- a/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.spec.ts
+++ b/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.spec.ts
@@ -167,4 +167,13 @@ describe('NotFoundPageComponent', () => {
 
     expect(fixture.point.componentInstance.invalidId).toBeUndefined();
   });
+
+  it('should create the component when URL path is /404', () => {
+    history.pushState(null, '', '/404');
+    
+    const fixture = MockRender(NotFoundPageComponent);
+    
+    expect(fixture.point.componentInstance).toBeTruthy();
+  });
+  
 });

--- a/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.spec.ts
+++ b/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.spec.ts
@@ -169,11 +169,21 @@ describe('NotFoundPageComponent', () => {
   });
 
   it('should create the component when URL path is /404', () => {
-    history.pushState(null, '', '/404');
-    
-    const fixture = MockRender(NotFoundPageComponent);
-    
-    expect(fixture.point.componentInstance).toBeTruthy();
-  });
+    const urlArray = ['404'];
+    MockInstance(
+      ActivatedRoute,
+      'snapshot',
+      jasmine.createSpy(),
+      'get'
+    ).and.returnValue({
+      url: urlArray.map(
+        urlItem => ({ toString: () => urlItem })
+      )
+    });
   
+    MockRender(NotFoundPageComponent);
+  
+    expect(ngMocks.findAll(NotFoundPageComponent)[0]).toBeTruthy();
+  });
+
 });

--- a/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.spec.ts
+++ b/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.spec.ts
@@ -13,13 +13,15 @@ import {
   NotFoundPageComponent,
   NotFoundReason
 } from './not-found-page.component';
+
 import { AppModule } from 'src/app/app.module';
+import { Location } from '@angular/common';
 
 describe('NotFoundPageComponent', () => {
   MockInstance.scope();
 
   beforeEach(() => {
-    return MockBuilder(NotFoundPageComponent, [AppModule, RouterModule]);
+    return MockBuilder(NotFoundPageComponent, [AppModule, RouterModule, Location]);
   });
 
   it('should create', () => {

--- a/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.ts
+++ b/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { Location } from '@angular/common';
 
 export enum NotFoundReason {
   Unknown,
@@ -22,6 +23,7 @@ export class NotFoundPageComponent {
   
   constructor(
     private route: ActivatedRoute,
+    private location: Location,
   ) { }
 
   ngOnInit() {
@@ -68,5 +70,9 @@ export class NotFoundPageComponent {
     }
 
     this.invalidId = this.url[2];
+  }
+
+  goBack() {
+    this.location.back();
   }
 }

--- a/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.ts
+++ b/ClientApp/src/app/components/pages/not-found-page/not-found-page.component.ts
@@ -27,6 +27,9 @@ export class NotFoundPageComponent {
   ) { }
 
   ngOnInit() {
+    // Use the pushState method of the history API to rewrite the URL path
+    history.pushState(null, '', '/404');
+
     this.getUrl();
     this.assignNotFoundReason();
     this.assignInvalidId();


### PR DESCRIPTION
### Fixed issues related to the footer and the 404 page.

The footer is now correctly placed on the bottom of the window if there is not enough content to fill the page (used to load the footer directly below all content and leave a white gap below the footer in some situations). Pages with enough content to push the footer to the bottom in the past continue to scroll properly.

URL now correctly sets to `/404`  on the error page. HTML and CSS have been modified to make the page a bit more intuitive and give a link to file an issue ticket (the same link as in the footer). Hitting the browser's back button will correctly load the last valid path accessed by the user.



<img width="960" alt="image" src="https://user-images.githubusercontent.com/63319043/236415554-ee070016-a6ac-4fc4-8c3c-9bcd8c3151f9.png">
