### PR TITLE
Task date edge case

### DIFF
--- a/ClientApp/src/app/components/miscellaneous/footer/footer.component.html
+++ b/ClientApp/src/app/components/miscellaneous/footer/footer.component.html
@@ -16,7 +16,7 @@
       </a>
     </div>
     <div class="footer-content-item">
-      <a href="https://github.com/NathanJesudason/Cuttlefish" target="_blank">
+      <a href="https://github.com/NathanJesudason/Cuttlefish/blob/main/CHANGELOG.md" target="_blank">
         <p-button styleClass="p-button-link" label="Changelog" icon="pi pi-external-link" iconPos="right"></p-button>
       </a>
     </div>

--- a/ClientApp/src/app/components/miscellaneous/sprint-dropdown/sprint-dropdown.component.spec.ts
+++ b/ClientApp/src/app/components/miscellaneous/sprint-dropdown/sprint-dropdown.component.spec.ts
@@ -20,6 +20,7 @@ import { SprintDropdownComponent } from './sprint-dropdown.component';
 import { DateInplaceComponent } from 'src/app/components/inplaces/date-inplace/date-inplace.component';
 import { DescriptionInplaceComponent } from 'src/app/components/inplaces/description-inplace/description-inplace.component';
 import { NgApexchartsModule } from 'ng-apexcharts';
+import { TaskData } from 'src/types/task';
 
 
 describe('SprintDropdownComponent', () => {
@@ -107,5 +108,88 @@ describe('SprintDropdownComponent', () => {
     expect(component.hidden).withContext('unhiding programmatically works').toBeFalse();
     accordion = ngMocks.find('p-accordionTab');
     expect(accordion).withContext('accordionTab exists again after calling unhide()').toBeTruthy();
+  });
+
+  it('should update a task\'s start and end dates when moving sprints', () => {
+    const inputTask1: TaskData = {
+      id: 1,
+      sprintID: 1,
+      name: '',
+      assignee: '',
+      description: '',
+      startDate: new Date(Date.parse('19 Jan 2023 00:00:00 GMT')),
+      endDate: new Date(Date.parse('23 Jan 2023 00:00:00 GMT')),
+      progress: 'Backlog',
+      type: 'Epic',
+      cost: 0,
+      storyPoints: 0,
+      priority: 0,
+      order: 0,
+      comments: [],
+    };
+
+    const expectedTask1: TaskData = {
+      id: 1,
+      sprintID: 1,
+      name: '',
+      assignee: '',
+      description: '',
+      startDate: new Date(Date.parse('4 Feb 2023 00:00:00 GMT')),
+      endDate: new Date(Date.parse('8 Feb 2023 00:00:00 GMT')),
+      progress: 'Backlog',
+      type: 'Epic',
+      cost: 0,
+      storyPoints: 0,
+      priority: 0,
+      order: 0,
+      comments: [],
+    };
+
+    const sprintStart1 = new Date(Date.parse('4 Feb 2023 00:00:00 GMT'));
+    const sprintEnd1 = new Date(Date.parse('18 Feb 2023 00:00:00 GMT'));
+    expect(SprintDropdownComponent.updateTaskDatesForNewSprint(inputTask1, sprintStart1, sprintEnd1))
+      .withContext('task is able to move forward into new sprint')
+      .toEqual(expectedTask1);
+    
+
+    const inputTask2: TaskData = {
+      id: 1,
+      sprintID: 1,
+      name: '',
+      assignee: '',
+      description: '',
+      startDate: new Date(Date.parse('19 Feb 2023 00:00:00 GMT')),
+      endDate: new Date(Date.parse('23 Feb 2023 00:00:00 GMT')),
+      progress: 'Backlog',
+      type: 'Epic',
+      cost: 0,
+      storyPoints: 0,
+      priority: 0,
+      order: 0,
+      comments: [],
+    };
+
+    const expectedTask2: TaskData = {
+      id: 1,
+      sprintID: 1,
+      name: '',
+      assignee: '',
+      description: '',
+      startDate: new Date(Date.parse('14 Feb 2023 00:00:00 GMT')),
+      endDate: new Date(Date.parse('18 Feb 2023 00:00:00 GMT')),
+      progress: 'Backlog',
+      type: 'Epic',
+      cost: 0,
+      storyPoints: 0,
+      priority: 0,
+      order: 0,
+      comments: [],
+    };
+
+    const sprintStart2 = new Date(Date.parse('4 Feb 2023 00:00:00 GMT'));
+    const sprintEnd2 = new Date(Date.parse('18 Feb 2023 00:00:00 GMT'));
+    expect(SprintDropdownComponent.updateTaskDatesForNewSprint(inputTask2, sprintStart2, sprintEnd2))
+      .withContext('task is able to move backward into new sprint')
+      .toEqual(expectedTask2);
   });
 });

--- a/ClientApp/src/app/components/miscellaneous/sprint-dropdown/sprint-dropdown.component.ts
+++ b/ClientApp/src/app/components/miscellaneous/sprint-dropdown/sprint-dropdown.component.ts
@@ -415,11 +415,19 @@ export class SprintDropdownComponent implements OnInit {
   }
 
   moveTasksToSprint(tasks: TaskData[]) {
-    for (const task of tasks) {
+    for (let task of tasks) {
       task.sprintID = this.selectedAvailableSprint.id;
-      this.taskService.putTask(task).subscribe({
-        next: () => {
-          this.data.tasks = this.data.tasks.filter(t => t.id !== task.id);
+      this.sprintService.getSprint(this.selectedAvailableSprint.id).subscribe({
+        next: (sprint) => {
+          task = SprintDropdownComponent.updateTaskDatesForNewSprint(task, sprint.startDate, sprint.endDate);
+          this.taskService.putTask(task).subscribe({
+            next: () => {
+              this.data.tasks = this.data.tasks.filter(t => t.id !== task.id);
+            },
+            error: (err) => {
+              this.messageService.add({severity: 'error', summary: err.message});
+            },
+          });
         },
         error: (err) => {
           this.messageService.add({severity: 'error', summary: err.message});
@@ -540,7 +548,7 @@ export class SprintDropdownComponent implements OnInit {
   }
 
   onTaskDrop(event: CdkDragDrop<TaskData[], TaskData[], TaskData>) {
-    const droppedTask = event.previousContainer.data[event.previousIndex];
+    let droppedTask = event.previousContainer.data[event.previousIndex];
     if (droppedTask.sprintID === this.data.id) {
       // task was dropped in the same sprint
       if (event.currentIndex === event.previousIndex) {
@@ -567,6 +575,7 @@ export class SprintDropdownComponent implements OnInit {
       this.moveTaskAcrossSprints.emit({ taskId: droppedTask.id, oldOrder: event.previousIndex, prevSprintId: droppedTask.sprintID });
       droppedTask.sprintID = this.data.id;
       droppedTask.order = event.currentIndex;
+      droppedTask = SprintDropdownComponent.updateTaskDatesForNewSprint(droppedTask, this.data.startDate, this.data.endDate);
       this.data.tasks.splice(event.currentIndex, 0, droppedTask);
       this.sprintOrderingService.addReorderTasksInSprint(this.data.id, event.currentIndex).subscribe({
         next: () => {
@@ -587,5 +596,39 @@ export class SprintDropdownComponent implements OnInit {
       });
     }
     
+  }
+
+  /**
+   * Helper function to constrain the start and end dates of a task to the start and end dates of a sprint
+   * 
+   * In theory this is called when a task is moving to a new sprint and the start and end dates need to be updated accordingly
+   * 
+   * @param task the task to update
+   * @param sprintStart the start date of the sprint
+   * @param sprintEnd the end date of the sprint
+   * @returns the updated task
+   */
+  static updateTaskDatesForNewSprint(task: TaskData, sprintStart: Date, sprintEnd: Date): TaskData {
+    if (task.startDate < sprintStart) {
+      const dateDiff = sprintStart.getTime() - task.startDate.getTime();
+      task.startDate = new Date(task.startDate.getTime() + dateDiff);
+      task.endDate = new Date(task.endDate.getTime() + dateDiff);
+      if (task.endDate > sprintEnd) {
+        task.endDate = sprintEnd;
+      }
+      return task;
+    }
+
+    if (task.endDate > sprintEnd) {
+      const dateDiff = task.endDate.getTime() - sprintEnd.getTime();
+      task.endDate = new Date(task.endDate.getTime() - dateDiff);
+      task.startDate = new Date(task.startDate.getTime() - dateDiff);
+      if (task.startDate < sprintStart) {
+        task.startDate = sprintStart;
+      }
+      return task;
+    }
+
+    return task;
   }
 }

--- a/ClientApp/src/types/task.ts
+++ b/ClientApp/src/types/task.ts
@@ -54,19 +54,7 @@ export type TaskData = {
 export function isTaskData(obj: any): obj is TaskData {
   return obj
     && obj.id !== undefined && typeof obj.id == 'number'
-    && obj.sprintID !== undefined && typeof obj.sprintID == 'number'
-    && obj.name !== undefined && typeof obj.name == 'string'
-    && obj.assignee !== undefined && typeof obj.assignee == 'string'
-    && obj.storyPoints !== undefined && typeof obj.storyPoints == 'number'
-    && obj.description !== undefined && typeof obj.description == 'string'
-    && obj.progress !== undefined && typeof obj.progress == 'string'
-    && obj.startDate !== undefined
-    && obj.endDate !== undefined
-    && obj.priority !== undefined && typeof obj.priority == 'number'
-    && obj.type !== undefined && typeof obj.type == 'string'
-    && obj.cost !== undefined && typeof obj.cost == 'number'
-    && obj.order !== undefined && typeof obj.order == 'number'
-    && obj.comments !== undefined && Array.isArray(obj.comments);
+    && obj.sprintID !== undefined && typeof obj.sprintID == 'number';
 }
 
 /**


### PR DESCRIPTION
There was an edge case we discovered where moving tasks between sprints didn't update the task's dates, making them invalid. I created a new function to perform that task date moving and wrote a couple unit tests for it. I also made sure the changelog button in the footer linked to the changelog and reverted the updates I made to `isTaskData()`.