### PR TITLE
Can now disable drag and drop

### DIFF
--- a/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.css
+++ b/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.css
@@ -55,6 +55,11 @@ a {
   grid-area: 1 / 2 / 2 / 4;
 }
 
+.nodragdrop-task-title {
+  grid-area: 1 / 1 / 2 / 4;
+  margin-left: 0.5rem;
+}
+
 .task-title-text:hover {
   text-decoration: underline;
   cursor: pointer;
@@ -68,6 +73,11 @@ a {
 
 .task-description {
   grid-area: 2 / 2 / 3 / 4;
+}
+
+.nodragdrop-task-description {
+  grid-area: 2 / 1 / 3 / 4;
+  margin-left: 0.5rem;
 }
 
 .task-labels {

--- a/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.html
+++ b/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.html
@@ -1,4 +1,54 @@
 <div
+  *ngIf="!dragDropEnabled"
+  class="task-overview"
+> 
+  <div class="nodragdrop-task-title">
+    <a
+      class="task-title-text"
+      [routerLink]="['/task', taskData.id]"
+    >{{taskData.id}}: {{taskData.name}}</a>
+  </div>
+
+  <div class="nodragdrop-task-description">
+    <p class="task-description-text">{{trimmedDescription}}</p>
+  </div>
+
+  <div class="task-labels">
+    <p-tag
+      *ngFor="let label of trimmedLabels"
+      [rounded]="true"
+      [style]="{'background': label.color}"
+      styleClass="mr-2"
+      [value]="label.name"
+    ></p-tag>
+  </div>
+
+  <p-tag
+    class="task-type"
+    styleClass="mr-2"
+    value="{{taskData.type}}"
+  ></p-tag>
+
+  <p-avatar
+    class="task-avatar"
+    shape="circle"
+    icon="pi pi-user"
+  ></p-avatar>
+
+  <task-progress-tag
+    class="task-progress"
+    [progress]="taskData.progress"
+  ></task-progress-tag>
+
+  <p-chip
+    class="task-story-points"
+    label="{{taskData.storyPoints}}"
+    styleClass="p-mr-2"
+  ></p-chip>
+</div>
+
+<div
+  *ngIf="dragDropEnabled"
   class="task-overview"
   cdkDrag
   (cdkDragMoved)="onDragMoved($event)"

--- a/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.ts
+++ b/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.ts
@@ -35,6 +35,12 @@ import { TaskData } from 'src/types/task';
 export class TaskOverviewComponent implements OnInit {
   @Input() taskData!: TaskData;
 
+  /**
+   * Whether or not the task is draggable.
+   * @default true
+   */
+  @Input() dragDropEnabled: boolean = true;
+
   trimmedDescription!: string;
   trimmedLabels: LabelData[] = [];
 
@@ -55,12 +61,20 @@ export class TaskOverviewComponent implements OnInit {
       this.trimmedDescription = 'No description';
       return;
     }
+
     const descriptionWithoutTags = this.taskData.description.replace(/<(?:"[^"]*"['"]*|'[^']*'['"]*|[^'">])+>/g, '');
     if (descriptionWithoutTags.length === 0) {
       this.trimmedDescription = 'No description';
-    } else {
-      this.trimmedDescription = `${descriptionWithoutTags.slice(0, 80)}...`;
+      return;
     }
+
+    const maxDescriptionCharacters = 80;
+    if (descriptionWithoutTags.length <= maxDescriptionCharacters) {
+      this.trimmedDescription = descriptionWithoutTags;
+      return;
+    }
+
+    this.trimmedDescription = `${descriptionWithoutTags.slice(0, maxDescriptionCharacters)}...`;
   }
 
   getLabels() {

--- a/ClientApp/src/app/components/pages/labels-page/labels-page.component.html
+++ b/ClientApp/src/app/components/pages/labels-page/labels-page.component.html
@@ -25,4 +25,5 @@
 <task-overview
   *ngFor="let task of tasksByLabel"
   [taskData]="task"
+  [dragDropEnabled]="false"
 ></task-overview>


### PR DESCRIPTION
I added a new input to the `task-overview` to disable drag and drop on it, which removes the draggable handle on the left side of it. I ended up having to copy and paste some HTML because it's not possible to conditionally apply a directive, which the angular cdk uses to implement drag and drop. So unfortunately, the basic and kinda clunky solution is to use `*ngIf`.

I also did a little bit of cleanup in the heat of the moment, so now the `task-overview`'s description only has ellipsis if the description had to be cut off for being too long. Previously, it just had ellipsis all the time and looked misleading.