### PR TITLE
Remove third party login and signup buttons

### DIFF
--- a/ClientApp/src/app/components/pages/login/login.component.html
+++ b/ClientApp/src/app/components/pages/login/login.component.html
@@ -45,12 +45,5 @@
         ></p-button>
       </div>
     </form>
-
-    <ng-template pTemplate="footer">
-      <p class="label-text">Log in with...</p>
-      <p-button id="facebook-button" icon="pi pi-facebook" [routerLink]="['/fb-login']"></p-button>
-      <p-button id="google-button" icon="pi pi-google"></p-button>
-      <p-button id="github-button" icon="pi pi-github"></p-button>
-    </ng-template>
   </p-card>
 </div>

--- a/ClientApp/src/app/components/pages/login/login.component.scss
+++ b/ClientApp/src/app/components/pages/login/login.component.scss
@@ -7,14 +7,14 @@
   color: var(--text-color);
 }
 
-#google-button, #github-button {
-  margin-left: var(--content-padding);
-}
-
 :host ::ng-deep {
   #signup-button button.p-button {
     margin-left: 0.5rem;
     padding: 0;
+  }
+
+  .p-card-content {
+    padding-bottom: 0;
   }
   
   p-card {

--- a/ClientApp/src/app/components/pages/signup/signup.component.html
+++ b/ClientApp/src/app/components/pages/signup/signup.component.html
@@ -70,12 +70,5 @@
         ></p-button>
       </div>
     </form>
-
-    <ng-template pTemplate="footer">
-      <p class="label-text">Sign up with...</p>
-      <p-button id="facebook-button" icon="pi pi-facebook" [routerLink]="['/fb-login']"></p-button>
-      <p-button id="google-button" icon="pi pi-google"></p-button>
-      <p-button id="github-button" icon="pi pi-github"></p-button>
-    </ng-template>
   </p-card>
 </div>

--- a/ClientApp/src/app/components/pages/signup/signup.component.scss
+++ b/ClientApp/src/app/components/pages/signup/signup.component.scss
@@ -7,14 +7,14 @@
   color: var(--text-color);
 }
 
-#google-button, #github-button {
-  margin-left: var(--content-padding);
-}
-
 :host ::ng-deep {
   #login-button button.p-button {
     margin-left: 0.5rem;
     padding: 0;
+  }
+
+  .p-card-content {
+    padding-bottom: 0;
   }
   
   p-card {


### PR DESCRIPTION
Removed the buttons to log in or sign up with Facebook, Google, and GitHub because those are features we didn't get around to and don't want to falsely advertise.

![image](https://github.com/NathanJesudason/Cuttlefish/assets/60301051/3a9563c7-0c2e-42e0-9b28-681bca7b86fd)

![image](https://github.com/NathanJesudason/Cuttlefish/assets/60301051/d93df7e3-5d6e-4777-a4b3-ff0d729d75c2)
