### PR TITLE
Small Gantt chart fixes

### DIFF
--- a/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.scss
+++ b/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.scss
@@ -6,3 +6,9 @@
 #cuttlefish-logo:hover {
   cursor: pointer;
 }
+
+:host ::ng-deep {
+  .p-menubar .p-submenu-list {
+    z-index: 1000;
+  }
+}

--- a/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.ts
+++ b/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.ts
@@ -27,7 +27,7 @@ import { CreateProjectModalComponent } from 'src/app/components/modals/create-pr
 @Component({
   selector: 'app-nav-menu',
   templateUrl: './nav-menu.component.html',
-  styleUrls: ['./nav-menu.component.css']
+  styleUrls: ['./nav-menu.component.scss']
 })
 export class NavMenuComponent implements OnInit {
   menuItems!: MenuItem[];

--- a/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.html
+++ b/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.html
@@ -132,7 +132,11 @@
         >{{ item.title }}</div>
       </ng-template>
       <ng-template #tableEmpty>
-        <div>Nothing to display for the current task view mode</div>
+        <div>
+          No information to display for the current task view mode! If task data is supposed
+          to be displayed here, ensure it has been created correctly on the 
+          <a [routerLink]="['/project', projectId]">project page</a>.
+        </div>
       </ng-template>
     </ngx-gantt>
   </ng-container>

--- a/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.html
+++ b/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.html
@@ -131,6 +131,9 @@
           tooltipPosition="bottom"
         >{{ item.title }}</div>
       </ng-template>
+      <ng-template #tableEmpty>
+        <div>Nothing to display for the current task view mode</div>
+      </ng-template>
     </ngx-gantt>
   </ng-container>
 </div>

--- a/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.ts
+++ b/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.ts
@@ -172,8 +172,8 @@ export class GanttPageComponent implements OnInit {
       let item: GanttItem = {
         id: `task-${task.id}`,
         title: `${task.id}: ${task.name} (${task.progress})`,
-        start: Math.round(task.startDate.getTime() / 1000),
-        end: Math.round(task.endDate.getTime() / 1000),
+        start: Math.floor(task.startDate.getTime() / 1000),
+        end: Math.floor(task.endDate.getTime() / 1000),
         color: progressColors[task.progress],
       };
 

--- a/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.ts
+++ b/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.ts
@@ -172,8 +172,8 @@ export class GanttPageComponent implements OnInit {
       let item: GanttItem = {
         id: `task-${task.id}`,
         title: `${task.id}: ${task.name} (${task.progress})`,
-        start: task.startDate.getTime() / 1000,
-        end: task.endDate.getTime() / 1000,
+        start: Math.round(task.startDate.getTime() / 1000),
+        end: Math.round(task.endDate.getTime() / 1000),
         color: progressColors[task.progress],
       };
 


### PR DESCRIPTION
This is a collection of 3 tiny bug fixes related to the Gantt chart:

1. The nav bar menu would show up underneath the gantt chart when it's expanded, so I made sure it's properly layered above
2. Used the `#tableEmpty` template to display a message for when the gantt chart is empty
3. Added an extra rounding operation when converting tasks to `GanttItem`s to make sure the chart doesn't get confused by non integer values