### PR TITLE
Small Gantt chart and other fixes

### DIFF
--- a/ClientApp/src/app/components/inplaces/date-inplace/date-inplace.component.ts
+++ b/ClientApp/src/app/components/inplaces/date-inplace/date-inplace.component.ts
@@ -84,6 +84,7 @@ export class DateInplaceComponent implements OnInit {
     }
 
     //Check if date range does not make sense
+    
     if((this.whichDate == 'start' && this.entityData.endDate && this.selectedDate > this.entityData.endDate)){
       this.messageService.add({severity: 'error', summary: 'Start date is ahead of end date'});
       this.cdr.detectChanges();
@@ -110,7 +111,8 @@ export class DateInplaceComponent implements OnInit {
 
     //Check if date range is outside of parent range
     if(this.validationEntityData != null){
-      if(this.selectedDate > this.validationEntityData.endDate || this.selectedDate < this.validationEntityData.startDate) {
+      const parentIsBacklog = isSprintData(this.validationEntityData) && this.validationEntityData.isBacklog;
+      if(!parentIsBacklog && (this.selectedDate > this.validationEntityData.endDate || this.selectedDate < this.validationEntityData.startDate)) {
         this.cdr.detectChanges();
         this.selectedDate = this.oldSelectedDate;
         if(isTaskData(this.entityData)){

--- a/ClientApp/src/app/components/inplaces/date-inplace/date-inplace.component.ts
+++ b/ClientApp/src/app/components/inplaces/date-inplace/date-inplace.component.ts
@@ -84,7 +84,6 @@ export class DateInplaceComponent implements OnInit {
     }
 
     //Check if date range does not make sense
-    
     if((this.whichDate == 'start' && this.entityData.endDate && this.selectedDate > this.entityData.endDate)){
       this.messageService.add({severity: 'error', summary: 'Start date is ahead of end date'});
       this.cdr.detectChanges();

--- a/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.ts
+++ b/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.ts
@@ -202,7 +202,8 @@ export class GanttPageComponent implements OnInit {
         title: sprint.name,
         expanded: true,
       });
-      const thisSprintItems = this.standardTasks(sprint.tasks).map(item => {
+      const sortedTasks = sprint.tasks.sort((a, b) => a.order - b.order);
+      const thisSprintItems = this.standardTasks(sortedTasks).map(item => {
         item.group_id = groupName;
         return item;
       });

--- a/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.ts
+++ b/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.ts
@@ -316,7 +316,9 @@ export class GanttPageComponent implements OnInit {
       return;
     }
 
-    if (proposedStartDate.getTime() < thisSprint.startDate.getTime()) {
+    const sprintIsBacklog = thisSprint.isBacklog;
+
+    if (!sprintIsBacklog && (proposedStartDate.getTime() < thisSprint.startDate.getTime())) {
       this.messageService.add({severity: 'error', summary: `Task cannot start before sprint start date, ${format(thisSprint.startDate, 'yyyy-MM-dd')}`, life: 5000});
       const itemIndex = this.items.findIndex(item => item.id === `task-${thisTask.id}`);
       this.items[itemIndex].start = thisTask.startDate.getTime() / 1000;
@@ -324,7 +326,7 @@ export class GanttPageComponent implements OnInit {
       return;
     }
 
-    if (proposedEndDate.getTime() > thisSprint.endDate.getTime()) {
+    if (!sprintIsBacklog && (proposedEndDate.getTime() > thisSprint.endDate.getTime())) {
       this.messageService.add({severity: 'error', summary: `Task cannot end after sprint end date, ${format(thisSprint.endDate, 'yyyy-MM-dd')}`, life: 5000});
       const itemIndex = this.items.findIndex(item => item.id === `task-${thisTask.id}`);
       this.items[itemIndex].end = thisTask.endDate.getTime() / 1000;

--- a/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.ts
+++ b/ClientApp/src/app/components/pages/gantt-page/gantt-page.component.ts
@@ -135,6 +135,7 @@ export class GanttPageComponent implements OnInit {
               for (const sprint of data.sprints) {
                 this.items.push(...this.standardTasks(sprint.tasks));
               }
+              this.items.sort((a, b) => a.start! - b.start!);
             } else if (this.taskOrganizationMode === 'epic') {
               const allTasks: TaskData[] = [];
               for (const sprint of data.sprints) {
@@ -323,6 +324,7 @@ export class GanttPageComponent implements OnInit {
       this.messageService.add({severity: 'error', summary: `Task cannot start before sprint start date, ${format(thisSprint.startDate, 'yyyy-MM-dd')}`, life: 5000});
       const itemIndex = this.items.findIndex(item => item.id === `task-${thisTask.id}`);
       this.items[itemIndex].start = thisTask.startDate.getTime() / 1000;
+      this.items[itemIndex].end = thisTask.endDate.getTime() / 1000;
       this.rerenderChart();
       return;
     }
@@ -330,6 +332,7 @@ export class GanttPageComponent implements OnInit {
     if (!sprintIsBacklog && (proposedEndDate.getTime() > thisSprint.endDate.getTime())) {
       this.messageService.add({severity: 'error', summary: `Task cannot end after sprint end date, ${format(thisSprint.endDate, 'yyyy-MM-dd')}`, life: 5000});
       const itemIndex = this.items.findIndex(item => item.id === `task-${thisTask.id}`);
+      this.items[itemIndex].start = thisTask.startDate.getTime() / 1000;
       this.items[itemIndex].end = thisTask.endDate.getTime() / 1000;
       this.rerenderChart();
       return;


### PR DESCRIPTION
- When a task is in a backlog, don't restrict the changing of its dates (on task page and gantt chart)
- In the Gantt chart's sprint view mode, order tasks within each sprint based on the `order` property
- In the Gantt chart's standard view mode, order tasks based on start date
- Fix small bug to properly reset task dates when there was an error when shifting dates