### PR TITLE
Implement avatars everywhere

### DIFF
--- a/ClientApp/src/app/components/inplaces/comment-inplace/comment-inplace.component.html
+++ b/ClientApp/src/app/components/inplaces/comment-inplace/comment-inplace.component.html
@@ -4,8 +4,7 @@
 >
   <p-avatar
     id="comment-avatar"
-    shape="circle"
-    icon="pi pi-user"
+    [image]="commenter.avatar"
   ></p-avatar>
 
   <div id="commenter-name" *ngIf="commenter">{{commenter.username}}</div>

--- a/ClientApp/src/app/components/inplaces/comment-inplace/comment-inplace.component.scss
+++ b/ClientApp/src/app/components/inplaces/comment-inplace/comment-inplace.component.scss
@@ -32,6 +32,10 @@
     margin-bottom: 0.3rem;
     color: var(--text-color);
   }
+
+  p-avatar {
+    height: 32px;
+  }
 }
 
 #edit-delete-buttons {

--- a/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.html
+++ b/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.html
@@ -10,7 +10,6 @@
   </ng-template>
   <ng-template pTemplate="end">
     <div
-      #userMenuIcon
       class="user-dropdown-button"
       (click)="userMenu.toggle($event)"
       (mouseleave)="userMenu.hide()"

--- a/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.html
+++ b/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.html
@@ -12,7 +12,6 @@
     <div
       class="user-dropdown-button"
       (click)="userMenu.toggle($event)"
-      (mouseleave)="userMenu.hide()"
     >
       <p-avatar
         *ngIf="signedInUser === undefined"

--- a/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.html
+++ b/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.html
@@ -13,6 +13,7 @@
       #userMenuIcon
       class="user-dropdown-button"
       (click)="userMenu.toggle($event)"
+      (mouseleave)="userMenu.hide()"
     >
       <p-avatar
         *ngIf="signedInUser === undefined"

--- a/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.html
+++ b/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.html
@@ -8,9 +8,36 @@
       [routerLink]="['/projects']"
     >
   </ng-template>
+  <ng-template pTemplate="end">
+    <div
+      #userMenuIcon
+      class="user-dropdown-button"
+      (click)="userMenu.toggle($event)"
+    >
+      <p-avatar
+        *ngIf="signedInUser === undefined"
+        class="user-avatar"
+        shape="circle"
+        icon="pi pi-user"
+      ></p-avatar>
+      <p-avatar
+        *ngIf="signedInUser !== undefined"
+        class="user-avatar"
+        [image]="signedInUser.avatar"
+      ></p-avatar>
+      <i class="pi pi-angle-down menu-icon"></i>
+    </div>
+    <p-menu
+      #userMenu
+      [model]="userMenuItems"
+      [popup]="true"
+    ></p-menu>
+  </ng-template>
 </p-menubar>
 
 <create-project-modal
   #createProjectModal
   [projects]="projects"
 ></create-project-modal>
+
+<p-toast></p-toast>

--- a/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.scss
+++ b/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.scss
@@ -11,4 +11,34 @@
   .p-menubar .p-submenu-list {
     z-index: 1000;
   }
+
+  .p-overlaypanel .p-overlaypanel-content {
+    padding: 0;
+  }
+}
+
+.user-dropdown-button {
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--border-radius);
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  column-gap: 0.75rem;
+}
+
+.user-dropdown-button > * {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
+.user-dropdown-button:hover {
+  cursor: pointer;
+  background-color: var(--surface-c);
+}
+
+.user-avatar {
+  height: 32px;
+}
+
+.menu-icon {
+  color: #6c757d;
 }

--- a/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.spec.ts
+++ b/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.spec.ts
@@ -12,17 +12,17 @@ import {
 import { MenubarModule } from 'primeng/menubar';
 import { AvatarModule } from 'primeng/avatar';
 import { MenuModule } from 'primeng/menu';
+import { ToastModule } from 'primeng/toast';
 
 import { ProjectData } from 'src/types/project';
+import { TeamMember } from 'src/types/team-member.model';
 
 import { ProjectService } from 'src/app/services/project/project.service';
+import { UserService } from 'src/app/services/user/user.service';
+import { TeamMemberService } from 'src/app/services/team-member/team-member.service';
 
 import { NavMenuComponent } from './nav-menu.component';
 import { CreateProjectModalComponent } from 'src/app/components/modals/create-project-modal/create-project-modal.component';
-import { ToastModule } from 'primeng/toast';
-import { UserService } from 'src/app/services/user/user.service';
-import { TeamMemberService } from 'src/app/services/team-member/team-member.service';
-import { TeamMember } from 'src/types/team-member.model';
 
 describe('NavMenuComponent', () => {
   const data: ProjectData = {

--- a/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.spec.ts
+++ b/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.spec.ts
@@ -10,6 +10,8 @@ import {
 } from 'rxjs';
 
 import { MenubarModule } from 'primeng/menubar';
+import { AvatarModule } from 'primeng/avatar';
+import { MenuModule } from 'primeng/menu';
 
 import { ProjectData } from 'src/types/project';
 
@@ -17,6 +19,10 @@ import { ProjectService } from 'src/app/services/project/project.service';
 
 import { NavMenuComponent } from './nav-menu.component';
 import { CreateProjectModalComponent } from 'src/app/components/modals/create-project-modal/create-project-modal.component';
+import { ToastModule } from 'primeng/toast';
+import { UserService } from 'src/app/services/user/user.service';
+import { TeamMemberService } from 'src/app/services/team-member/team-member.service';
+import { TeamMember } from 'src/types/team-member.model';
 
 describe('NavMenuComponent', () => {
   const data: ProjectData = {
@@ -59,11 +65,17 @@ describe('NavMenuComponent', () => {
   };
   
   beforeEach(() => {
-    return MockBuilder(NavMenuComponent, [MenubarModule])
+    return MockBuilder(NavMenuComponent, [MenubarModule, MenuModule, AvatarModule, ToastModule])
       .mock(CreateProjectModalComponent, { export: true })
       .mock(ProjectService, {
         getAllProjects: (id: number): Observable<ProjectData[]> => of([data]),
-      } as Partial<ProjectService>);
+      } as Partial<ProjectService>)
+      .mock(UserService, {
+        getUserName: () => of('Test User'),
+      } as Partial<UserService>)
+      .mock(TeamMemberService, {
+        getTeamMemberByUsername: () => of({} as TeamMember),
+      } as Partial<TeamMemberService>);
   });
 
   it('should create', () => {

--- a/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.ts
+++ b/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.ts
@@ -15,7 +15,10 @@ import {
   ViewChild
 } from '@angular/core';
 
-import { MenuItem, MessageService } from 'primeng/api';
+import {
+  MenuItem,
+  MessageService
+} from 'primeng/api';
 
 import { ProjectData } from 'src/types/project';
 
@@ -26,7 +29,6 @@ import { UserService } from 'src/app/services/user/user.service';
 
 import { CreateProjectModalComponent } from 'src/app/components/modals/create-project-modal/create-project-modal.component';
 import { TeamMember } from 'src/types/team-member.model';
-import { ContextMenu } from 'primeng/contextmenu';
 
 @Component({
   selector: 'app-nav-menu',

--- a/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.ts
+++ b/ClientApp/src/app/components/miscellaneous/nav-menu/nav-menu.component.ts
@@ -15,22 +15,28 @@ import {
   ViewChild
 } from '@angular/core';
 
-import { MenuItem } from 'primeng/api';
+import { MenuItem, MessageService } from 'primeng/api';
 
 import { ProjectData } from 'src/types/project';
 
 import { AuthService } from 'src/app/services/auth/auth.service';
 import { ProjectService } from 'src/app/services/project/project.service';
+import { TeamMemberService } from 'src/app/services/team-member/team-member.service';
+import { UserService } from 'src/app/services/user/user.service';
 
 import { CreateProjectModalComponent } from 'src/app/components/modals/create-project-modal/create-project-modal.component';
+import { TeamMember } from 'src/types/team-member.model';
+import { ContextMenu } from 'primeng/contextmenu';
 
 @Component({
   selector: 'app-nav-menu',
   templateUrl: './nav-menu.component.html',
-  styleUrls: ['./nav-menu.component.scss']
+  styleUrls: ['./nav-menu.component.scss'],
+  providers: [MessageService],
 })
 export class NavMenuComponent implements OnInit {
   menuItems!: MenuItem[];
+  userMenuItems!: MenuItem[];
   projects!: ProjectData[];
 
   @ViewChild('createProjectModal') createProjectModal!: ElementRef<CreateProjectModalComponent>;
@@ -39,14 +45,20 @@ export class NavMenuComponent implements OnInit {
   item: string = ""
   currentItem!: string | null
 
+  signedInUser!: TeamMember;
+
   constructor(
-    private auth: AuthService,
+    private authService: AuthService,
     private projectService: ProjectService,
+    private userService: UserService,
+    private teamMemberService: TeamMemberService,
+    private messageService: MessageService,
   ) {}
 
   
 
   ngOnInit() {
+    this.getSignedInUser();
     this.assignMenuItems();
   }
 
@@ -73,26 +85,18 @@ export class NavMenuComponent implements OnInit {
         label: 'Team Members',
         routerLink: ['/teammembers'],
       },
+    ];
+
+    this.userMenuItems = [
       {
         icon: 'pi pi-user',
-        items: [
-          {
-            icon: 'pi pi-user',
-            label: 'Account',
-            routerLink: ['/account']
-          },
-          {
-            icon: 'pi pi-cog',
-            label: 'Settings',
-          },
-          {
-            icon: 'pi pi-sign-out',
-            label: 'Sign Out',
-            command: (event)   => 
-            { this.signOut()}
-            ,
-          },
-        ],
+        label: 'Account',
+        routerLink: ['/account']
+      },
+      {
+        icon: 'pi pi-sign-out',
+        label: 'Sign Out',
+        command: (event) => {this.signOut()},
       },
     ];
 
@@ -115,8 +119,24 @@ export class NavMenuComponent implements OnInit {
     
   }
 
+  getSignedInUser() {
+    this.userService.getUserName().subscribe({
+      next: (username: string) => {
+        const signedInUserName = username || this.authService.getUsernameFromToken();
+        this.teamMemberService.getTeamMemberByUsername(signedInUserName).subscribe({
+          next: (teamMember: TeamMember) => {
+            this.signedInUser = teamMember;
+          },
+          error: (err) => {
+            this.messageService.add({severity: 'error', summary: err.error.message});
+          },
+        });
+      },
+    });
+  }
+
 
   signOut(){
-    this.auth.signOut()
+    this.authService.signOut()
   }
 }

--- a/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.css
+++ b/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.css
@@ -103,3 +103,7 @@ a {
     grid-area: 1 / auto / 3 / auto;
   }
 }
+
+.task-avatar {
+  height: 32px;
+}

--- a/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.html
+++ b/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.html
@@ -30,9 +30,16 @@
   ></p-tag>
 
   <p-avatar
+    *ngIf="assignee === undefined"
     class="task-avatar"
     shape="circle"
     icon="pi pi-user"
+  ></p-avatar>
+
+  <p-avatar
+    *ngIf="assignee !== undefined"
+    class="task-avatar"
+    [image]="assignee.avatar"
   ></p-avatar>
 
   <task-progress-tag
@@ -89,9 +96,16 @@
   ></p-tag>
 
   <p-avatar
+    *ngIf="assignee === undefined"
     class="task-avatar"
     shape="circle"
     icon="pi pi-user"
+  ></p-avatar>
+
+  <p-avatar
+    *ngIf="assignee !== undefined"
+    class="task-avatar"
+    [image]="assignee.avatar"
   ></p-avatar>
 
   <task-progress-tag

--- a/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.ts
+++ b/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.ts
@@ -50,8 +50,6 @@ export class TaskOverviewComponent implements OnInit {
 
   scrollFrameNumber: number = 0;
 
-  loadingAvatar: boolean = true;
-
   constructor(
     private taskService: TaskApi,
     private messageService: MessageService,
@@ -70,14 +68,12 @@ export class TaskOverviewComponent implements OnInit {
       this.taskData.assignee_id === null ||
       this.taskData.assignee_id === undefined
     ) {
-      // this.loadingAvatar = false;
       return;
     }
 
     this.teamMemberService.getTeamMemberById(this.taskData.assignee_id).subscribe({
       next: (assignee) => {
         this.assignee = assignee;
-        // this.loadingAvatar = false;
       },
       error: (err) => {
         this.messageService.add({severity: 'error', summary: err.message})

--- a/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.ts
+++ b/ClientApp/src/app/components/miscellaneous/task-overview/task-overview.component.ts
@@ -22,9 +22,11 @@ import {
 import { MessageService } from 'primeng/api';
 
 import { TaskApi } from 'src/app/services/tasks/tasks.service';
+import { TeamMemberService } from 'src/app/services/team-member/team-member.service';
 import { LabelData } from 'src/types/label';
 
 import { TaskData } from 'src/types/task';
+import { TeamMember } from 'src/types/team-member.model';
 
 @Component({
   selector: 'task-overview',
@@ -41,19 +43,46 @@ export class TaskOverviewComponent implements OnInit {
    */
   @Input() dragDropEnabled: boolean = true;
 
+  assignee!: TeamMember;
+
   trimmedDescription!: string;
   trimmedLabels: LabelData[] = [];
 
   scrollFrameNumber: number = 0;
 
+  loadingAvatar: boolean = true;
+
   constructor(
     private taskService: TaskApi,
     private messageService: MessageService,
+    private teamMemberService: TeamMemberService,
   ) { }
 
   ngOnInit(): void {
+    this.getAssignee();
     this.getLabels();
     this.getTrimmedDescription();
+  }
+
+  getAssignee() {
+    if (
+      this.taskData.assignee_id === 0 ||
+      this.taskData.assignee_id === null ||
+      this.taskData.assignee_id === undefined
+    ) {
+      // this.loadingAvatar = false;
+      return;
+    }
+
+    this.teamMemberService.getTeamMemberById(this.taskData.assignee_id).subscribe({
+      next: (assignee) => {
+        this.assignee = assignee;
+        // this.loadingAvatar = false;
+      },
+      error: (err) => {
+        this.messageService.add({severity: 'error', summary: err.message})
+      },
+    });
   }
 
   getTrimmedDescription() {

--- a/ClientApp/src/app/services/auth/auth.service.ts
+++ b/ClientApp/src/app/services/auth/auth.service.ts
@@ -11,6 +11,8 @@ import {
   catchError,
   throwError
 } from 'rxjs';
+import { funEmoji } from '@dicebear/collection';
+import { createAvatar } from '@dicebear/core';
 
 import { environment } from 'src/environments/environment';
 
@@ -42,7 +44,11 @@ export class AuthService {
    * @returns an observable of the response from the backend
    */
   signUp(teammemberObj : any){
-    return this.http.post<any>(`${this.baseUrl}register`, teammemberObj)
+    const randomAvatarUri = createAvatar(funEmoji, {
+      seed: teammemberObj.email,
+      radius: 30,
+    }).toDataUriSync();
+    return this.http.post<any>(`${this.baseUrl}register`, {...teammemberObj, avatar: randomAvatarUri})
       .pipe(
         catchError((err: HttpErrorResponse) => {
           if (err.status === HttpStatusCode.Conflict) {

--- a/ClientApp/src/app/services/tasks/tasks.service.ts
+++ b/ClientApp/src/app/services/tasks/tasks.service.ts
@@ -60,6 +60,7 @@ export class TaskApi {
     })
     .pipe(
       map((taskData: TaskData) => {
+        taskData.assignee_id = Number(taskData.assignee);
         return {
           ...taskData,
           startDate: new Date(taskData.startDate as any),
@@ -87,6 +88,7 @@ export class TaskApi {
     .pipe(
       map((taskData: TaskData[]) => {
         return taskData.map((task: TaskData) => {
+          task.assignee_id = Number(task.assignee);
           return {
             ...task,
             startDate: new Date(task.startDate as any),


### PR DESCRIPTION
Added avatars to `task-overview`, `comment-inplace`, and `nav-menu`.

![image](https://github.com/NathanJesudason/Cuttlefish/assets/60301051/9e9fa8f5-c688-473a-9be5-bb3e8915d0ce)

![image](https://github.com/NathanJesudason/Cuttlefish/assets/60301051/dd028aa3-40a4-4ad8-b457-b716ff3cb138)

![image](https://github.com/NathanJesudason/Cuttlefish/assets/60301051/c61ffda5-eb42-42da-ba15-98590cdc9b9f)

I also set up the auth service to assign an avatar when creating a new account, with the account's email as the seed.